### PR TITLE
(Fix) Warning when number of moves is equal to limit

### DIFF
--- a/analyse_log.sh
+++ b/analyse_log.sh
@@ -53,8 +53,8 @@ lowest=${sorted[0]}
 highest=${sorted[-1]}
 
 COLOR=$CYAN
-if [ "$list_size" -eq 5 -a "$highest" -ge "$LIMIT_5" ] || [ "$list_size" -eq 100 -a "$highest" -ge "$LIMIT_100" ] || \
-	[ "$list_size" -eq 500 -a "$highest" -ge "$LIMIT_500" ]; then
+if [ "$list_size" -eq 5 -a "$highest" -gt "$LIMIT_5" ] || [ "$list_size" -eq 100 -a "$highest" -gt "$LIMIT_100" ] || \
+	[ "$list_size" -eq 500 -a "$highest" -gt "$LIMIT_500" ]; then
     COLOR=$HRED
 	printf "\n$COLOR ERROR: YOU ARE DOING TOO MANY MOVEMENTS SOMEWHERE, CHECK YOUR WORST CASE AND LOG FILES\n"
 fi


### PR DESCRIPTION
Hello, @Vinni-Cedraz !

This pull request changes the operator that compares number of movements with a set limit (dependent on the size of the list of numbers to be sorted).

Previous code issued the warning if the number of movements was greater **or equal** to set limit. However, if the number of operations is equal to the limit, the project is still compliant with the evaluation scale (which can be found [here](https://rphlr.github.io/42-Evals/Cursus/Push_swap/)).

Changing the operator from "greater than or equal" to "greater than" corrects this behavior.

Congratulations on the tester!
Kind regards,
iury